### PR TITLE
Bump Microsoft.VisualStudio.Azure.Containers.Tools.Targets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageVersion Include="MinimalApi.Endpoint" Version="1.3.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />


### PR DESCRIPTION
Bumps Microsoft.VisualStudio.Azure.Containers.Tools.Targets from 1.20.1 to 1.21.0.

---
updated-dependencies:
- dependency-name: Microsoft.VisualStudio.Azure.Containers.Tools.Targets dependency-type: direct:production update-type: version-update:semver-minor ...